### PR TITLE
Downgrade rack dependency to 1.1

### DIFF
--- a/mobvious.gemspec
+++ b/mobvious.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "rack", ">= 1.2.0"
+  s.add_runtime_dependency "rack", ">= 1.1.0"
   s.add_runtime_dependency "mobileesp_converted", '~> 0.2.0'
 
 


### PR DESCRIPTION
I couldn't find any reason for limiting rack to 1.2+ (I didn't search very long for one either, truth be told).

This should allow support for Rails 2.3 apps (2.3.18 requires `rack ~> 1.1.0`).

Instructions :
- Manually `require 'mobvious'` in `config/environment.rb`
- In the same file, insert `config.middleware.use Mobvious::Manager`

:warning: I only tested this in one app, running rails 2.3.18 & rack 1.1.6.
