### PR TITLE
Pull request: Changes in gem file and in documentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 # == SPECIAL DEVELOPMENT DEPS HANDLING ==
 
 # temporarily switched for this fork, because the current version of guard-minitest has broken notifications
-gem 'guard-minitest', git: 'git://github.com/aspiers/guard-minitest', ref: '4b660261d35'
+gem 'guard-minitest', git: 'git://github.com/aspiers/guard-minitest'
 gem 'mocha', require: false
 gem 'turn', require: false
+gem 'minitest', "~> 4.7.5"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ fork your front-end code with regard to device type. There is a
     `config/initializers/mobvious.rb` and use this config to begin with:
 
         Mobvious.configure do |config|
-          config.strategies = [ Mobvious::Strategies::MobileESP.new ]
+          config.strategies = [ Mobvious::Strategies::MobileESP.new(:mobile_tablet_desktop) ]
         end
 
 4.  **Done! From now on, device type is detected for each request.**  


### PR DESCRIPTION
As discussed: The diff in the gemfile allowed me to test on my machine as it is now.

The parameter in the MobileESP initialisation defaults to the strategy that returns tablet if present.
